### PR TITLE
Fix repo-wide lint

### DIFF
--- a/src/swaps_rv/ann/__init__.py
+++ b/src/swaps_rv/ann/__init__.py
@@ -24,16 +24,15 @@ Notes
 from pathlib import Path
 from typing import Dict
 
-import jax
-import jax.numpy as jnp
 import haiku as hk
+import jax.numpy as jnp
 
 from .residual_net import ResidualNet
-
 
 # ---------------------------------------------------------------------------
 # Factory helpers
 # ---------------------------------------------------------------------------
+
 
 def get_resnet(cfg: Dict) -> hk.Transformed:
     """
@@ -56,6 +55,7 @@ def get_resnet(cfg: Dict) -> hk.Transformed:
     haiku.Transformed
         Haiku pair with .init(rng, x) and .apply(params, rng, x) call-signatures.
     """
+
     def _forward(x, is_training: bool = False):
         net = ResidualNet(**cfg)
         return net(x, is_training=is_training)

--- a/src/swaps_rv/cli/backtest.py
+++ b/src/swaps_rv/cli/backtest.py
@@ -22,16 +22,15 @@ from typing import List
 
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
-
-from gp.tiered_gp import TieredGP
 from ann.residual_net import ResidualNet, ResidualNetConfig  # new API
+from gp.tiered_gp import TieredGP
+from tqdm import tqdm
 from utils import calibration as ucal
-from utils import data as udata  # (unused for now, kept for future live‑feed work)
 
 # --------------------------------------------------------------------------- #
 # CLI helpers
 # --------------------------------------------------------------------------- #
+
 
 def _parse(argv: List[str] | None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
@@ -47,14 +46,18 @@ def _parse(argv: List[str] | None) -> argparse.Namespace:
         choices=["USD", "EUR", "GBP", "JPY"],
         help="Market currency (holiday calendar).",
     )
-    p.add_argument("--lookback", type=int, default=750, help="Days to feed the ANN (≈3y).")
+    p.add_argument(
+        "--lookback", type=int, default=750, help="Days to feed the ANN (≈3y)."
+    )
     p.add_argument(
         "--out",
         type=pathlib.Path,
         default=pathlib.Path("bt") / datetime.now().strftime("%Y-%m-%d_%H%M"),
         help="Output folder.",
     )
-    p.add_argument("--cache", action="store_true", help="Cache per‑day GP pickles for debug.")
+    p.add_argument(
+        "--cache", action="store_true", help="Cache per‑day GP pickles for debug."
+    )
     p.add_argument("--jit", action="store_true", help="Enable Numba JIT in TieredGP.")
 
     return p.parse_args(argv)
@@ -63,6 +66,7 @@ def _parse(argv: List[str] | None) -> argparse.Namespace:
 # --------------------------------------------------------------------------- #
 # Back‑test driver (signals only)
 # --------------------------------------------------------------------------- #
+
 
 def main(argv: List[str] | None = None):  # pragma: no cover
     args = _parse(argv)

--- a/src/swaps_rv/cli/build_curve.py
+++ b/src/swaps_rv/cli/build_curve.py
@@ -17,17 +17,16 @@ from __future__ import annotations
 
 import argparse
 import pathlib
-import sys
 import pickle
+import sys
 from datetime import datetime
 
 import numpy as np  # noqa: F401  (kept for future extensions)
 import pandas as pd
-
+from ann.residual_net import ResidualNet
 from gp.tiered_gp import TieredGP
-from ann.residual_net import ResidualNet          # ← unified class name
-from utils import data as udata
 from utils import calibration as ucal
+from utils import data as udata
 from utils import plots as uplt
 
 
@@ -106,7 +105,7 @@ def main(argv: list[str] | None = None) -> None:  # pragma: no cover
         quotes,
         tiers=tier_cfg,
         ois_curve=ois_quotes,
-        kernel="Brownian",        # default
+        kernel="Brownian",  # default
         optimize_prior=True,
         jit=args.jit,
     )
@@ -131,8 +130,10 @@ def main(argv: list[str] | None = None) -> None:  # pragma: no cover
     # ------------------------------------------------------------------ #
     # 5. Diagnostics
     if args.plot:
-        uplt.curve(gp, save_to=args.out / "ifr.png")          # IFR curve
-        uplt.ann_surface(ann, save_to=args.out / "ann.png")   # ANN residual map
+        uplt.curve(gp, save_to=args.out / "ifr.png")  # IFR curve
+        uplt.ann_surface(
+            ann, X_train, y_train, save_to=args.out / "ann.png"
+        )  # ANN residual map
 
     print("✅  Build finished:", args.out)
 

--- a/src/swaps_rv/gp/__init__.py
+++ b/src/swaps_rv/gp/__init__.py
@@ -16,12 +16,17 @@ from typing import Any, Callable
 # ---------------------------------------------------------------------------
 # Public re-exports
 # ---------------------------------------------------------------------------
-
 # kernels -------------------------------------------------------------------
 from . import kernels as kernels  # noqa: F401 – re-export
 
 # interpolators -------------------------------------------------------------
 from .interpolators import get as _get_interp  # noqa: F401 – re-export
+from .tiered_gp import (
+    USD_TIERS as _USD_TIERS,
+)
+from .tiered_gp import (
+    TierConfig as _TierConfig,
+)
 
 # ---------------------------------------------------------------------------
 # Tiered GP façade
@@ -29,11 +34,8 @@ from .interpolators import get as _get_interp  # noqa: F401 – re-export
 # ``tiered_gp.py`` defines ``TieredGP`` (curve engine) and the tier helpers.
 # We expose them at the package level so that users can simply write
 #     from swaps_rv.gp import TieredGP, TierConfig, USD_TIERS
-
 from .tiered_gp import (  # noqa: E402  – keep grouped import
     TieredGP as _TieredGP,
-    TierConfig as _TierConfig,
-    USD_TIERS as _USD_TIERS,
 )
 
 # preferred handle ----------------------------------------------------------

--- a/src/swaps_rv/gp/_core.py
+++ b/src/swaps_rv/gp/_core.py
@@ -14,7 +14,6 @@ heap‑allocated by Numba without relying on Python objects.
 from __future__ import annotations
 
 import numpy as np
-import numpy.linalg as npl  # kept for non‑JIT code paths; *inside* @njit we use np.linalg
 
 # ---------------------------------------------------------------------------
 # Optional Numba import – graceful degradation on lightweight installs
@@ -36,6 +35,7 @@ except ModuleNotFoundError:  # pragma: no cover – optional acceleration
         """Serial replacement for numba.prange."""
 
         return range(n)
+
 
 # ---------------------------------------------------------------------------
 # Covariance matrices
@@ -112,6 +112,3 @@ def gp_conditional_cov(
     """Posterior covariance Σ_x − Λ Σ_y⁻¹ Λᵀ  (eq. 9)."""
     L = np.linalg.solve(Σ_y, Σ_x.T)  # Σ_y⁻¹ Λᵀ
     return Σ - Σ_x @ L
-
-
-

--- a/src/swaps_rv/gp/interpolators/flat.py
+++ b/src/swaps_rv/gp/interpolators/flat.py
@@ -28,7 +28,6 @@ Notes
 
 from __future__ import annotations
 
-import math
 from typing import Sequence
 
 try:
@@ -112,11 +111,12 @@ class FlatForward:
 # Registry hook used by gp.interpolators.__init__.py
 # -------------------------------------------------------------------------
 
+
 def factory(*args, **kwargs):
     """Entry-point required by the registry (`get("flat")`)."""
     return FlatForward(*args, **kwargs)
 
+
 # ---------------------------------------------------------------------------
 # public alias expected by the registry
 Interpolator = FlatForward
-

--- a/src/swaps_rv/gp/interpolators/tension_spline.py
+++ b/src/swaps_rv/gp/interpolators/tension_spline.py
@@ -15,11 +15,13 @@ Author: 2025-05-12
 
 from __future__ import annotations
 
-import numpy as np
-from numba import njit, prange
 from typing import Callable
 
+import numpy as np
+from numba import njit
+
 # --------------------------------------------------------------------- helpers
+
 
 @njit(cache=True)
 def _phi(h, σ, τ):
@@ -28,16 +30,16 @@ def _phi(h, σ, τ):
         # limit σ→0  → cubic term
         return (h - τ) ** 3 / (6.0 * h)
     s = np.sinh(σ * h)
-    return (np.sinh(σ * (h - τ)) - σ * (h - τ)) / (σ ** 2 * s)
+    return (np.sinh(σ * (h - τ)) - σ * (h - τ)) / (σ**2 * s)
 
 
 @njit(cache=True)
 def _psi(h, σ, τ):
     """Ψ_j(t)  (τ := t – t_j)"""
     if σ == 0.0:
-        return τ ** 3 / (6.0 * h)
+        return τ**3 / (6.0 * h)
     s = np.sinh(σ * h)
-    return (np.sinh(σ * τ) - σ * τ) / (σ ** 2 * s)
+    return (np.sinh(σ * τ) - σ * τ) / (σ**2 * s)
 
 
 @njit(cache=True)
@@ -50,8 +52,6 @@ def _build_B(knots: np.ndarray, sigma: np.ndarray):
     n = len(knots) - 1
     coeffs = np.empty((n, 4, 4))  # segment, basis-idx, poly-coeff
     for j in range(n):
-        h = knots[j + 1] - knots[j]
-        σ = sigma[j]
         # polynomial on [t_j,t_{j+1}]  expressed as  a + b τ + c Φ + d Ψ
         # derive segment-local coefficients following Koch-Lyche.
         coeffs[j, 0, 0] = 1.0  # placeholder, overwritten later
@@ -63,10 +63,9 @@ def _build_B(knots: np.ndarray, sigma: np.ndarray):
 
 
 @njit(cache=True, parallel=False)
-def _eval_spline(x: np.ndarray,
-                 knots: np.ndarray,
-                 sigma: np.ndarray,
-                 beta: np.ndarray) -> np.ndarray:
+def _eval_spline(
+    x: np.ndarray, knots: np.ndarray, sigma: np.ndarray, beta: np.ndarray
+) -> np.ndarray:
     """
     Evaluate tension spline at arbitrary grid x.
 
@@ -87,10 +86,13 @@ def _eval_spline(x: np.ndarray,
         # local basis indices j-1..j+2  map to beta idx k-1..k+2
         # build on the fly
         Bm1 = _phi(h, σ, τ) * (knots[k + 1] - knots[k - 1]) / h if k > 0 else 0.0
-        B0  = ((τ / h) - 1.0) - Bm1
-        B1  = (1.0 - τ / h) - _psi(h, σ, τ) * (knots[k + 2] - knots[k]) / h \
-              if k + 2 < beta.size + 2 else 0.0
-        B2  = _psi(h, σ, τ) * (knots[k + 2] - knots[k]) / h if k + 1 < beta.size else 0.0
+        B0 = ((τ / h) - 1.0) - Bm1
+        B1 = (
+            (1.0 - τ / h) - _psi(h, σ, τ) * (knots[k + 2] - knots[k]) / h
+            if k + 2 < beta.size + 2
+            else 0.0
+        )
+        B2 = _psi(h, σ, τ) * (knots[k + 2] - knots[k]) / h if k + 1 < beta.size else 0.0
 
         acc = 0.0
         if k - 1 >= 0:
@@ -105,6 +107,7 @@ def _eval_spline(x: np.ndarray,
 
 
 # ------------------------------------------------------------------- interface
+
 
 class TensionSpline:
     """
@@ -128,8 +131,11 @@ class TensionSpline:
         if self.knots.ndim != 1 or np.any(np.diff(self.knots) <= 0):
             raise ValueError("knots must be 1-D increasing array")
         n_seg = len(self.knots) - 1
-        self.sigma = (np.full(n_seg, float(sigma))
-                      if np.isscalar(sigma) else np.asarray(sigma, float))
+        self.sigma = (
+            np.full(n_seg, float(sigma))
+            if np.isscalar(sigma)
+            else np.asarray(sigma, float)
+        )
         if self.sigma.shape != (n_seg,):
             raise ValueError("sigma length must equal len(knots)-1")
         # pre-build nothing heavy; evaluation builds on-the-fly
@@ -137,9 +143,7 @@ class TensionSpline:
 
     # ---------------------------------------------------------------- call
 
-    def __call__(self,
-                 grid: np.ndarray,
-                 beta: np.ndarray) -> np.ndarray:
+    def __call__(self, grid: np.ndarray, beta: np.ndarray) -> np.ndarray:
         grid = np.asarray(grid, float)
         if beta.ndim != 1 or len(beta) != len(self.knots) - 2:
             raise ValueError("beta length must be len(knots)-2 (interior)")
@@ -147,9 +151,9 @@ class TensionSpline:
 
     # ---------------------------------------------------------------- jacobian
 
-    def jacobian(self,
-                 grid: np.ndarray,
-                 beta: np.ndarray) -> Callable[[np.ndarray], np.ndarray]:
+    def jacobian(
+        self, grid: np.ndarray, beta: np.ndarray
+    ) -> Callable[[np.ndarray], np.ndarray]:
         """
         Return a *linear map* J such that  J @ δβ = δf(grid).
 
@@ -170,9 +174,12 @@ class TensionSpline:
             cols.extend(np.full(nz.sum(), j))
             data.extend(df[nz])
         from scipy.sparse import coo_matrix
+
         m = len(grid)
         J = coo_matrix((data, (rows, cols)), shape=(m, n_beta)).tocsr()
         return J
+
+
 # ---------------------------------------------------------------------------
 # public alias expected by the registry
-Interpolator = TensionSpline          # <── ADD THIS
+Interpolator = TensionSpline  # <── ADD THIS

--- a/src/swaps_rv/gp/kernels.py
+++ b/src/swaps_rv/gp/kernels.py
@@ -35,13 +35,13 @@ from typing import Dict
 
 try:  # use JAX if available
     import jax.numpy as np  # type: ignore
-    from jax import lax
 except ModuleNotFoundError:  # fall back to NumPy
     import numpy as np  # type: ignore
 
 ###############################################################################
 # helpers
 ###############################################################################
+
 
 def _as_col(x):
     """Ensure x is an (N,1) column array."""
@@ -63,6 +63,7 @@ def _pairwise_diffs(x, y):
 # kernels
 ###############################################################################
 
+
 def SE(x, y, θ: Dict[str, float]):
     """
     Squared-exponential (RBF) kernel
@@ -74,9 +75,10 @@ def SE(x, y, θ: Dict[str, float]):
     θ : dict
         Must contain keys ``"σ"`` (amplitude) and ``"ℓ"`` (length-scale).
     """
-    σ, ℓ = θ["σ"], θ["ℓ"]
+    σ = θ["σ"]
+    ell = θ["ℓ"]
     x, y = _as_col(x), _as_col(y)
-    r = _pairwise_diffs(x / ℓ, y / ℓ)
+    r = _pairwise_diffs(x / ell, y / ell)
     return σ * σ * np.exp(-0.5 * r * r)
 
 
@@ -86,10 +88,11 @@ def Matern52(x, y, θ: Dict[str, float]):
 
         k(r) = σ² * (1 + √5 r/ℓ + 5 r²/(3ℓ²)) * exp(-√5 r/ℓ)
     """
-    σ, ℓ = θ["σ"], θ["ℓ"]
+    σ = θ["σ"]
+    ell = θ["ℓ"]
     x, y = _as_col(x), _as_col(y)
-    r = _pairwise_diffs(x, y) / ℓ
-    f = (1.0 + np.sqrt(5.0) * r + 5.0 * r * r / 3.0)
+    r = _pairwise_diffs(x, y) / ell
+    f = 1.0 + np.sqrt(5.0) * r + 5.0 * r * r / 3.0
     return σ * σ * f * np.exp(-np.sqrt(5.0) * r)
 
 
@@ -114,10 +117,11 @@ def OU(x, y, θ: Dict[str, float]):
 
     Equivalent to Matérn-½.
     """
-    σ, ℓ = θ["σ"], θ["ℓ"]
+    σ = θ["σ"]
+    ell = θ["ℓ"]
     x, y = _as_col(x), _as_col(y)
     r = _pairwise_diffs(x, y)
-    return σ * σ * np.exp(-r / ℓ)
+    return σ * σ * np.exp(-r / ell)
 
 
 ###############################################################################

--- a/src/swaps_rv/utils/__init__.py
+++ b/src/swaps_rv/utils/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import importlib
 import types
-from typing import Any, Callable
+from typing import Callable
 
 __all__ = [
     "data",
@@ -31,6 +31,7 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Lazy sub‑module loader (keeps import footprint tiny)
 # ---------------------------------------------------------------------------
+
 
 def _lazy(name: str) -> Callable[[], types.ModuleType]:
     """Return a proxy loader so ``import utils.<name>`` is truly lazy."""

--- a/src/swaps_rv/utils/data.py
+++ b/src/swaps_rv/utils/data.py
@@ -31,10 +31,12 @@ import datetime as _dt
 import gzip
 import pickle
 from pathlib import Path
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import pandas as pd
 
+if TYPE_CHECKING:  # pragma: no cover
+    from gp.tiered_gp import TieredGP
 
 # --------------------------------------------------------------------------- #
 # Quotes loader
@@ -54,11 +56,7 @@ def load_quotes(path: str | Path, *, tz: str = "UTC") -> pd.DataFrame:
         .dropna()
     )
     df["timestamp"] = df["timestamp"].dt.tz_localize(tz)
-    return (
-        df.set_index(["timestamp", "ticker"])
-        .sort_index()
-        .astype({"mid": "float64"})
-    )
+    return df.set_index(["timestamp", "ticker"]).sort_index().astype({"mid": "float64"})
 
 
 # --------------------------------------------------------------------------- #
@@ -82,7 +80,7 @@ def load_curve_snapshots(dir_: str | Path) -> List["TieredGP"]:
 
     for p in dir_path.glob("*.pkl*"):
         ts = _ts_from_filename(p.name)
-        with (gzip.open(p, "rb") if p.suffix == ".gz" else p.open("rb")) as fh:
+        with gzip.open(p, "rb") if p.suffix == ".gz" else p.open("rb") as fh:
             snaps.append((ts, pickle.load(fh)))
 
     snaps.sort(key=lambda t: t[0])

--- a/src/swaps_rv/utils/plots.py
+++ b/src/swaps_rv/utils/plots.py
@@ -25,7 +25,7 @@ No DV01 / bucket‑risk code is kept in this trimmed version.
 
 from __future__ import annotations
 
-from typing import Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -39,12 +39,13 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:  # pragma: no cover – import only for static typing
-    from gp.tiered_gp import TieredGP
     from ann.residual_net import ResidualNet
+    from gp.tiered_gp import TieredGP
 
 # --------------------------------------------------------------------------- #
 # internal helper
 # --------------------------------------------------------------------------- #
+
 
 def _ax(ax):
     if ax is None:
@@ -56,6 +57,7 @@ def _ax(ax):
 # --------------------------------------------------------------------------- #
 # GP visualisations
 # --------------------------------------------------------------------------- #
+
 
 def curve(gp: "TieredGP", *, ax=None, show_liq: bool = True):
     """Instantaneous‑forward curve plus par‑swap markers."""
@@ -105,6 +107,7 @@ def residuals(gp: "TieredGP", *, ax=None):
 # ANN diagnostics
 # --------------------------------------------------------------------------- #
 
+
 def ann_surface(
     net: "ResidualNet",
     X: np.ndarray,
@@ -142,6 +145,7 @@ def ann_surface(
 # --------------------------------------------------------------------------- #
 # Thin wrappers to keep backward‑compat with the original CLI scripts
 # --------------------------------------------------------------------------- #
+
 
 def plot_ifr(gp: "TieredGP", *, save_to: str | None = None, **kwargs):
     """Wrapper around :pyfunc:`curve` that also handles file output."""


### PR DESCRIPTION
## Summary
- clean up imports across modules
- fix unicode minus signs in `ResidualNetConfig`
- forward training data when plotting ANN surface

## Testing
- `ruff check`
- `black --check src/swaps_rv/cli/build_curve.py src/swaps_rv/cli/backtest.py src/swaps_rv/ann/__init__.py src/swaps_rv/ann/residual_net.py src/swaps_rv/gp/__init__.py src/swaps_rv/gp/_core.py src/swaps_rv/gp/interpolators/flat.py src/swaps_rv/gp/interpolators/tension_spline.py src/swaps_rv/gp/kernels.py src/swaps_rv/utils/__init__.py src/swaps_rv/utils/data.py src/swaps_rv/utils/plots.py --check`
