### PR TITLE
Update imports to absolute swaps_rv paths

### DIFF
--- a/src/swaps_rv/cli/backtest.py
+++ b/src/swaps_rv/cli/backtest.py
@@ -22,11 +22,11 @@ from typing import List
 
 import numpy as np
 import pandas as pd
-
-from ann.residual_net import ResidualNet, ResidualNetConfig  # new API
-from gp.tiered_gp import TieredGP
 from tqdm import tqdm
-from utils import calibration as ucal
+
+from swaps_rv.ann.residual_net import ResidualNet, ResidualNetConfig  # new API
+from swaps_rv.gp.tiered_gp import TieredGP
+from swaps_rv.utils import calibration as ucal
 
 # --------------------------------------------------------------------------- #
 # CLI helpers

--- a/src/swaps_rv/cli/build_curve.py
+++ b/src/swaps_rv/cli/build_curve.py
@@ -23,11 +23,12 @@ from datetime import datetime
 
 import numpy as np  # noqa: F401  (kept for future extensions)
 import pandas as pd
-from ann.residual_net import ResidualNet
-from gp.tiered_gp import TieredGP
-from utils import calibration as ucal
-from utils import data as udata
-from utils import plots as uplt
+
+from swaps_rv.ann.residual_net import ResidualNet
+from swaps_rv.gp.tiered_gp import TieredGP
+from swaps_rv.utils import calibration as ucal
+from swaps_rv.utils import data as udata
+from swaps_rv.utils import plots as uplt
 
 
 # --------------------------------------------------------------------------- #

--- a/src/swaps_rv/utils/data.py
+++ b/src/swaps_rv/utils/data.py
@@ -35,9 +35,8 @@ from typing import TYPE_CHECKING, List
 
 import pandas as pd
 
-
 if TYPE_CHECKING:  # pragma: no cover
-    from gp.tiered_gp import TieredGP
+    from swaps_rv.gp.tiered_gp import TieredGP
 
 # --------------------------------------------------------------------------- #
 # Quotes loader

--- a/src/swaps_rv/utils/plots.py
+++ b/src/swaps_rv/utils/plots.py
@@ -39,8 +39,8 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:  # pragma: no cover – import only for static typing
-    from ann.residual_net import ResidualNet
-    from gp.tiered_gp import TieredGP
+    from swaps_rv.ann.residual_net import ResidualNet
+    from swaps_rv.gp.tiered_gp import TieredGP
 
 # --------------------------------------------------------------------------- #
 # internal helper


### PR DESCRIPTION
## Summary
- switch CLI scripts and utils modules to absolute imports using `swaps_rv`

## Testing
- `ruff check src/swaps_rv/cli/backtest.py src/swaps_rv/cli/build_curve.py src/swaps_rv/utils/data.py src/swaps_rv/utils/plots.py`
- `black --check src/swaps_rv/cli/backtest.py src/swaps_rv/cli/build_curve.py src/swaps_rv/utils/data.py src/swaps_rv/utils/plots.py`
